### PR TITLE
Fix boolean filter query handling

### DIFF
--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,0 +1,37 @@
+export interface Filters {
+  country: string;
+  riskScore: [number, number];
+  alliance: '' | 'nato' | 'five_eyes' | 'oecd' | 'quad';
+  sanctions: boolean;
+  dumping: boolean;
+  taa: boolean;
+}
+
+export function buildLocationQuery(filters: Filters, search: string = ''): string {
+  const params = new URLSearchParams();
+  if (filters.country) params.set('country', filters.country);
+  if (filters.riskScore) {
+    params.set('risk_min', String(filters.riskScore[0]));
+    params.set('risk_max', String(filters.riskScore[1]));
+  }
+  if (filters.sanctions) params.set('ofac_sanctioned', 'true');
+  if (filters.dumping) params.set('engages_in_dumping', 'true');
+  if (filters.taa) params.set('taa_compliant', 'true');
+  switch (filters.alliance) {
+    case 'nato':
+      params.set('is_nato', 'true');
+      break;
+    case 'five_eyes':
+      params.set('is_five_eyes', 'true');
+      break;
+    case 'oecd':
+      params.set('is_oecd', 'true');
+      break;
+    case 'quad':
+      params.set('is_quad', 'true');
+      break;
+  }
+  if (search) params.set('q', search);
+  const query = params.toString();
+  return query ? `/api/locations?${query}` : '/api/locations';
+}


### PR DESCRIPTION
## Summary
- handle risk score min/max and boolean flags in `LocationsController`
- return alliance/OFAC/dumping/TAA flags with location JSON
- add a small helper to build location filter query strings

## Testing
- `npm run lint` *(fails: cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6859f3f05ed88321b2f3bcfe4493d165