### PR TITLE
Add shortage status filter

### DIFF
--- a/frontend/src/components/MapView.tsx
+++ b/frontend/src/components/MapView.tsx
@@ -25,8 +25,22 @@ interface Location {
   is_quad?: boolean;
 }
 
+interface Drug {
+  id: number;
+  shortage_start?: string | null;
+  shortage_end?: string | null;
+}
+
+interface NDC {
+  id: number;
+  drug_id: number;
+  location_id: number;
+}
+
 interface MapViewProps {
   locations: Location[];
+  drugs: Drug[];
+  ndcs: NDC[];
   filters: any;
   searchQuery: string;
   onLocationSelect: (location: Location) => void;
@@ -41,6 +55,8 @@ const getRiskColorHex = (riskScore: number) => {
 
 const MapView: React.FC<MapViewProps> = ({
   locations,
+  drugs,
+  ndcs,
   filters,
   searchQuery,
   onLocationSelect,
@@ -118,6 +134,26 @@ const MapView: React.FC<MapViewProps> = ({
       if (filters.alliance === 'oecd' && !loc.is_oecd) return false;
       if (filters.alliance === 'quad' && !loc.is_quad) return false;
 
+      if (filters.shortageStatus) {
+        const locationNdcs = ndcs.filter(n => n.location_id === loc.id);
+        const drugIds = new Set(locationNdcs.map(n => n.drug_id));
+        const relatedDrugs = drugs.filter(d => drugIds.has(d.id));
+
+        const matches = relatedDrugs.some(d => {
+          const ongoing = d.shortage_start && !d.shortage_end;
+          const resolved =
+            (d.shortage_start && d.shortage_end) || (!d.shortage_start && d.shortage_end);
+          const never = !d.shortage_start && !d.shortage_end;
+
+          if (filters.shortageStatus === 'ongoing') return ongoing;
+          if (filters.shortageStatus === 'resolved') return resolved;
+          if (filters.shortageStatus === 'never') return never;
+          return true;
+        });
+
+        if (!matches) return false;
+      }
+
       // Smart search
       if (query) {
         const match = [
@@ -156,7 +192,7 @@ const MapView: React.FC<MapViewProps> = ({
     if (source) {
       source.setData(geojson);
     }
-  }, [locations, filters, searchQuery]);
+  }, [locations, drugs, ndcs, filters, searchQuery]);
 
   return <div ref={mapContainer} className="h-full w-full rounded-xl overflow-hidden" />;
 };

--- a/frontend/src/components/MapView.tsx
+++ b/frontend/src/components/MapView.tsx
@@ -34,6 +34,11 @@ interface Drug {
 interface NDC {
   id: number;
   drug_id: number;
+}
+
+interface NDCLocationLink {
+  id: number;
+  ndc_id: number;
   location_id: number;
 }
 
@@ -41,6 +46,7 @@ interface MapViewProps {
   locations: Location[];
   drugs: Drug[];
   ndcs: NDC[];
+  ndcLocationLinks: NDCLocationLink[];
   filters: any;
   searchQuery: string;
   onLocationSelect: (location: Location) => void;
@@ -57,6 +63,7 @@ const MapView: React.FC<MapViewProps> = ({
   locations,
   drugs,
   ndcs,
+  ndcLocationLinks,
   filters,
   searchQuery,
   onLocationSelect,
@@ -135,8 +142,12 @@ const MapView: React.FC<MapViewProps> = ({
       if (filters.alliance === 'quad' && !loc.is_quad) return false;
 
       if (filters.shortageStatus) {
-        const locationNdcs = ndcs.filter(n => n.location_id === loc.id);
-        const drugIds = new Set(locationNdcs.map(n => n.drug_id));
+        const locationLinks = ndcLocationLinks.filter(link => link.location_id === loc.id);
+        const drugIds = new Set<number>();
+        locationLinks.forEach(link => {
+          const ndc = ndcs.find(n => n.id === link.ndc_id);
+          if (ndc && typeof ndc.drug_id === 'number') drugIds.add(ndc.drug_id);
+        });
         const relatedDrugs = drugs.filter(d => drugIds.has(d.id));
 
         const matches = relatedDrugs.some(d => {
@@ -192,7 +203,7 @@ const MapView: React.FC<MapViewProps> = ({
     if (source) {
       source.setData(geojson);
     }
-  }, [locations, drugs, ndcs, filters, searchQuery]);
+  }, [locations, drugs, ndcs, ndcLocationLinks, filters, searchQuery]);
 
   return <div ref={mapContainer} className="h-full w-full rounded-xl overflow-hidden" />;
 };

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -126,6 +126,19 @@ const Sidebar: React.FC<SidebarProps> = ({
                   <option value="quad">QUAD</option>
                 </select>
               </div>
+              <div>
+                <label className="block text-sm font-medium text-slate-300 mb-2">Shortage Status</label>
+                <select
+                  value={filters.shortageStatus}
+                  onChange={(e) => handleFilterChange('shortageStatus', e.target.value)}
+                  className="w-full bg-slate-700 border border-slate-600 rounded-lg px-3 py-2 text-white text-sm"
+                >
+                  <option value="">All</option>
+                  <option value="ongoing">Ongoing Shortage</option>
+                  <option value="resolved">Resolved Shortage</option>
+                  <option value="never">Never in Shortage</option>
+                </select>
+              </div>
               <div className="space-y-2">
                 <label className="flex items-center">
                   <input

--- a/frontend/src/pages/Index.tsx
+++ b/frontend/src/pages/Index.tsx
@@ -56,6 +56,13 @@ interface NDC {
   drug_dosage: string;
   drug_strength: string;
   manufacturer_name: string;
+  drug_id: number;
+}
+
+interface NDCLocationLink {
+  id: number;
+  ndc_id: number;
+  location_id: number;
 }
 
 const Index = () => {
@@ -67,6 +74,7 @@ const Index = () => {
   const [drugs, setDrugs] = useState<Drug[]>([]);
   const [manufacturers, setManufacturers] = useState<Manufacturer[]>([]);
   const [ndcs, setNDCs] = useState<NDC[]>([]);
+  const [ndcLocationLinks, setNdcLocationLinks] = useState<NDCLocationLink[]>([]);
   const [filters, setFilters] = useState({
     country: '',
     riskScore: [0, 10],
@@ -81,17 +89,19 @@ const Index = () => {
   useEffect(() => {
     const fetchData = async () => {
       try {
-        const [locationsRes, drugsRes, manufacturersRes, ndcsRes] = await Promise.all([
+        const [locationsRes, drugsRes, manufacturersRes, ndcsRes, linksRes] = await Promise.all([
           fetch(`${API_URL}/api/locations`),
           fetch(`${API_URL}/api/drugs`),
           fetch(`${API_URL}/api/manufacturers`),
-          fetch(`${API_URL}/api/ndcs`)
+          fetch(`${API_URL}/api/ndcs`),
+          fetch(`${API_URL}/api/ndc_location_links`)
         ]);
 
         if (locationsRes.ok) setLocations(await locationsRes.json());
         if (drugsRes.ok) setDrugs(await drugsRes.json());
         if (manufacturersRes.ok) setManufacturers(await manufacturersRes.json());
         if (ndcsRes.ok) setNDCs(await ndcsRes.json());
+        if (linksRes.ok) setNdcLocationLinks(await linksRes.json());
       } catch (error) {
         console.error('Error fetching data:', error);
       } finally {
@@ -208,6 +218,7 @@ const Index = () => {
               locations={enrichedLocations}
               drugs={drugs}
               ndcs={ndcs}
+              ndcLocationLinks={ndcLocationLinks}
               filters={filters}
               searchQuery={searchQuery}
               onLocationSelect={handleLocationSelect}

--- a/frontend/src/pages/Index.tsx
+++ b/frontend/src/pages/Index.tsx
@@ -73,6 +73,7 @@ const Index = () => {
     alliance: '',
     sanctions: false,
     dumping: false,
+    shortageStatus: '',
   });
   const [searchQuery, setSearchQuery] = useState<{ query: string; type: 'location' | 'drug' | 'manufacturer' | 'ndc' }>({ query: '', type: 'location' });
   const [isLoading, setIsLoading] = useState(true);
@@ -205,6 +206,8 @@ const Index = () => {
             {/* Only show MapView for now */}
             <MapView
               locations={enrichedLocations}
+              drugs={drugs}
+              ndcs={ndcs}
               filters={filters}
               searchQuery={searchQuery}
               onLocationSelect={handleLocationSelect}

--- a/rails_app/app/controllers/api/ndcs_controller.rb
+++ b/rails_app/app/controllers/api/ndcs_controller.rb
@@ -9,7 +9,8 @@ class Api::NdcsController < ApplicationController
         proprietary_name: ndc.proprietary_name,
         drug_dosage: ndc.drug_dosage,
         drug_strength: ndc.drug_strength,
-        manufacturer_name: ndc.manufacturer&.manufacturer_name
+        manufacturer_name: ndc.manufacturer&.manufacturer_name,
+        drug_id: ndc.drug_id
       }
     }
   end
@@ -23,7 +24,8 @@ class Api::NdcsController < ApplicationController
       proprietary_name: ndc.proprietary_name,
       drug_dosage: ndc.drug_dosage,
       drug_strength: ndc.drug_strength,
-      manufacturer_name: ndc.manufacturer&.manufacturer_name
+      manufacturer_name: ndc.manufacturer&.manufacturer_name,
+      drug_id: ndc.drug_id
     }
   end
 end


### PR DESCRIPTION
## Summary
- add `shortageStatus` to filter state
- filter locations by linked drug shortage status in `MapView`
- include shortage status dropdown in sidebar
- pass `drugs` and `ndcs` to `MapView`

## Testing
- `npm run lint` *(fails: node not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685c115962f0832198b01ec12ac7e633